### PR TITLE
#1 Use only one db by choosing related profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # DB Switcher
+
+## Build and run (via command line)
+
+To run application with PostgreSQL db follow next steps:
+### Step #1 Run PostgreSQL
+```
+docker-compose up -d postgres
+```
+### Step #2 Run application with profile 'dev'
+```
+./gradlew clean bootRun -PenvId=dev
+```
+
+To run application with H2 db follow next steps:
+### Run application with profile 'local'
+```
+./gradlew clean bootRun -PenvId=local
+```
+
+#### [Attention] When no selected env id then local env id is used
+
+## Build and run (via command line)
+
+### Step 1. Edit configuration
+### Step 2. Add Gradle task
+### Step 3. Use related gradle command to run certain launch variant

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,7 @@
 plugins {
     id 'org.springframework.boot' version '2.7.1'
     id 'io.spring.dependency-management' version '1.0.11.RELEASE'
+    id 'io.freefair.lombok' version '6.5.0.3'
     id 'java'
 }
 
@@ -12,7 +13,20 @@ repositories {
     mavenCentral()
 }
 
+def envId = project.findProperty('envId') ?: 'local'
+
+def envDbDriver = [
+        'local': 'com.h2database:h2',
+        'dev'  : 'org.postgresql:postgresql'
+]
+
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    runtimeOnly 'org.postgresql:postgresql'
+    runtimeOnly envDbDriver[envId] ?: envDbDriver['local']
+}
+
+bootRun {
+    def activeProfile = envDbDriver.containsKey(envId) ? envId : 'local'
+
+    systemProperty 'spring.profiles.active', activeProfile
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+services:
+  postgres:
+    image: postgres
+    ports:
+      - '5432:5432'
+    environment:
+      POSTGRES_PASSWORD: postgres

--- a/src/main/java/com/example/dbswticher/DbDriverInfoPrinter.java
+++ b/src/main/java/com/example/dbswticher/DbDriverInfoPrinter.java
@@ -1,0 +1,37 @@
+package com.example.dbswticher;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationStartedEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class DbDriverInfoPrinter {
+
+    private final Environment environment;
+
+    @EventListener
+    public void handle(ApplicationStartedEvent event) {
+        log.info("Active profile: {}", Arrays.toString(environment.getActiveProfiles()));
+
+        String[] driverClassNames = {
+                "org.h2.Driver",
+                "org.postgresql.Driver"
+        };
+
+        for (String driverClassName : driverClassNames) {
+            try {
+                Class.forName(driverClassName);
+                log.info("Driver [{}] is loaded", driverClassName);
+            } catch (ClassNotFoundException e) {
+                log.warn("Driver [{}] is missing", driverClassName);
+            }
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,0 @@
-spring.datasource.url=jdbc:postgresql://localhost:5432/postgres?user=postgres&password=postgres
-spring.datasource.username=postgres
-spring.datasource.password=postgres
-
-spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQL10Dialect

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,14 @@
+---
+spring:
+  config:
+    activate:
+      on-profile: dev
+
+  datasource.url: jdbc:postgresql://localhost:5432/postgres?user=postgres&password=postgres
+---
+spring:
+  config:
+    activate:
+      on-profile: local
+
+  datasource.url: jdbc:h2:mem:db


### PR DESCRIPTION
Goal: select only on db driver and use selected db.

# Implementation details
1. Use Gradle property to select certain Spring profile and db driver.
1. (as consequence) onle one db driver in classpath.
1. Gradle property activates Spring profile to define db connection url.

## Some example to run application with H2
```
./gradlew clean bootRun -PenvId=local
```

or to run application with PostgreSQL (requires launched PostgreSQL server on localhost)
```
./gradlew clean bootRun -PenvId=dev
```

To simplify testing the pull request provides `docker-compose.yml` to run PostgreSQL on local machine.